### PR TITLE
Find correctly matching <!-- endbower --> tag for <!-- bower:js -->

### DIFF
--- a/tasks/separate-cdn.js
+++ b/tasks/separate-cdn.js
@@ -33,7 +33,9 @@ module.exports = function(grunt) {
         var matches_array =[];
         var result = '';
         var cdnScriptTags = [];
-        var bowerContent = content.substring(content.indexOf("<!-- bower:js -->"), content.indexOf("<!-- endbower -->"));
+        var bowerTagStartIdx = content.indexOf("<!-- bower:js -->");
+        var bowerTagEndIdx = content.indexOf("<!-- endbower -->", bowerTagStartIdx);
+        var bowerContent = content.substring(bowerTagStartIdx, bowerTagEndIdx);
 
         while ((matches_array = cdnPattern.exec(bowerContent)) !== null) {
             result = result + matches_array[0];


### PR DESCRIPTION
If there is a bower:css and endbower tag before bower:js tag then the first  endbower (matching the css) is found. This starts searching for endbower starting from bower.js tag.
